### PR TITLE
fix: do not execute usermod, groupmod

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -113,15 +113,15 @@ if [ "${1}" = "minio" ]; then
   # Stop temporary MinIO server.
   minio_stop_temp_server
 
-  if [ -n "${MY_UID:-0}" ] && [ "${MY_UID:-0}" != "0" ]; then
-    usermod -u "${MY_UID:-0}" minio
-  fi
-  if [ -n "${MY_GID:-0}" ] && [ "${MY_GID:-0}" != "0" ]; then
-    groupmod -g "${MY_GID:-0}" minio
-  fi
+  # No need to execute the following, minio runs ok with a (potentially) userless approach.
+  #   usermod -u "${MY_UID:-0}" minio
+  #   groupmod -g "${MY_GID:-0}" minio
 
   chown -R "${MY_UID:-0}" "${BUCKET_ROOT}"
   chgrp -R "${MY_GID:-0}" "${BUCKET_ROOT}"
+
+  minio_log Debug "MY_UID=${MY_UID:-not set}"
+  minio_log Debug "MY_GID=${MY_GID:-not set}"
 
   # Run minio.
   gosu "${MY_UID:-0}:${MY_GID:-0}" /usr/bin/minio server "${BUCKET_ROOT}" --address ":${MINIO_PORT}" --console-address ":${MINIO_CONSOLE_PORT}" ${MINIO_OPTS}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed `usermod`/`groupmod` calls for userless container approach

- Added debug logging for `MY_UID` and `MY_GID` variables


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MinIO Entrypoint"] -- "previously" --> B["usermod/groupmod execution"]
  A -- "now" --> C["Skip usermod/groupmod"]
  C -- "then" --> D["chown/chgrp BUCKET_ROOT"]
  D -- "then" --> E["Log MY_UID and MY_GID"]
  E -- "then" --> F["gosu minio server start"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Remove usermod/groupmod, add UID/GID debug logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/entrypoint.sh

<ul><li>Commented out <code>usermod</code> and <code>groupmod</code> commands to support userless <br>container approach<br> <li> Added debug log statements to output <code>MY_UID</code> and <code>MY_GID</code> values at <br>runtime</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/Docker-MinIO/pull/31/files#diff-913fb747600da65f297c9fe6e47a424f47ac65e051960d33be397e4153929241">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

